### PR TITLE
Updated  lru_cache decorator.

### DIFF
--- a/pyconverse/utils.py
+++ b/pyconverse/utils.py
@@ -9,13 +9,13 @@ from sklearn.metrics.pairwise import cosine_similarity
 from transformers import pipeline
 
 
-@lru_cache
+@lru_cache()
 def load_sentence_transformer(model_name='all-MiniLM-L6-v2'):
     model = SentenceTransformer(model_name)
     return model
 
 
-@lru_cache
+@lru_cache()
 def load_spacy():
     return spacy.load('en_core_web_sm')
 


### PR DESCRIPTION
After installing and running the library pyconverse on python-3.7 or below and using the import statement it gives error in import itself. I went through the utils file and saw that the "@lru_cache" decorator was written as per the new python(i.e. 3.8+) style hence when calling in older versions(py 3.7 and below it raises a NoneType Error) as the LRU_CACHE decorator is written as -" @lru_cache() " with paranthesis for older versions .  Hence made the changes. The changes made do not cause any error on the newer versions.